### PR TITLE
Capitalised FormBuilderTwigExtension

### DIFF
--- a/formbuilder/FormBuilderPlugin.php
+++ b/formbuilder/FormBuilderPlugin.php
@@ -248,7 +248,7 @@ class FormBuilderPlugin extends BasePlugin
     public function addTwigExtension()
     {
         Craft::import('plugins.formBuilder.twigextensions.formBuilderTwigExtension');
-        return new formBuilderTwigExtension();
+        return new FormBuilderTwigExtension();
     }
 
     // Private Methods


### PR DESCRIPTION
Was causing a class not found error on windows/nginx host